### PR TITLE
fix return of mysql_handle_commit

### DIFF
--- a/ext/pdo_mysql/mysql_driver.c
+++ b/ext/pdo_mysql/mysql_driver.c
@@ -329,7 +329,7 @@ static int mysql_handle_commit(pdo_dbh_t *dbh TSRMLS_DC)
 	PDO_DBG_ENTER("mysql_handle_commit");
 	PDO_DBG_INF_FMT("dbh=%p", dbh);
 #if MYSQL_VERSION_ID >= 40100 || defined(PDO_USE_MYSQLND)
-	PDO_DBG_RETURN(0 <= mysql_commit(((pdo_mysql_db_handle *)dbh->driver_data)->server));
+	PDO_DBG_RETURN(0 == mysql_commit(((pdo_mysql_db_handle *)dbh->driver_data)->server));
 #else
 	PDO_DBG_RETURN(0 <= mysql_handle_doer(dbh, ZEND_STRL("COMMIT") TSRMLS_CC));
 #endif


### PR DESCRIPTION
We use the distributed database TIDB, which is compatible with the mysql protocol, but it uses an optimistic transaction model that will cause COMMIT to return an error. But the mysql_handle_commit () function does not distinguish between this error.

mysql_commit() return enum_func_status, and it cause mysql_handle_commit() always return 1.

```
typedef enum func_status
{
	PASS = 0,
	FAIL = 1
} enum_func_status;

static int mysql_handle_commit(pdo_dbh_t *dbh)
{
	PDO_DBG_ENTER("mysql_handle_commit");
	PDO_DBG_INF_FMT("dbh=%p", dbh);
#if MYSQL_VERSION_ID >= 40100 || defined(PDO_USE_MYSQLND)
	PDO_DBG_RETURN(0 <= mysql_commit(((pdo_mysql_db_handle *)dbh->driver_data)->server));
#else
	PDO_DBG_RETURN(0 <= mysql_handle_doer(dbh, ZEND_STRL("COMMIT")));
#endif
}
```

[here is the log of mysqlnd](https://github.com/yaoguais/cabin/blob/master/tidb/trans_test/mysqlnd.trace.2.separate/27579.log#L648)

It really return "FAIL", but mysql_handle_commit() return 1.

Then PDO will not throw an exception, and it cause an error.